### PR TITLE
Modify /resources/{id}/available

### DIFF
--- a/src/main/java/com/csemosip/bookingservice/controller/ResourcesController.java
+++ b/src/main/java/com/csemosip/bookingservice/controller/ResourcesController.java
@@ -1,5 +1,6 @@
 package com.csemosip.bookingservice.controller;
 
+import com.csemosip.bookingservice.dto.ResourceAvailabilityDTO;
 import com.csemosip.bookingservice.dto.ResourceDTO;
 import com.csemosip.bookingservice.exception.ResourceNotFoundException;
 import com.csemosip.bookingservice.model.Resource;
@@ -53,7 +54,7 @@ public class ResourcesController extends AbstractController {
             @RequestParam("timeslot") String timeslot
     ) {
         try {
-            List<Map<String, Object>> availabilityList = resourceService.getAvailabilityByResourceIdAndTimeslot(resourceId, timeslot);
+            List<ResourceAvailabilityDTO> availabilityList = resourceService.getAvailabilityByResourceIdAndTimeslot(resourceId, timeslot);
             return sendSuccessResponse(availabilityList, HttpStatus.OK);
         } catch (ResourceNotFoundException e) {
             return sendBadRequestResponse(e.getMessage());

--- a/src/main/java/com/csemosip/bookingservice/controller/ResourcesController.java
+++ b/src/main/java/com/csemosip/bookingservice/controller/ResourcesController.java
@@ -6,11 +6,13 @@ import com.csemosip.bookingservice.exception.ResourceNotFoundException;
 import com.csemosip.bookingservice.model.Resource;
 import com.csemosip.bookingservice.service.ResourceService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -52,10 +54,15 @@ public class ResourcesController extends AbstractController {
     @PreAuthorize("hasAnyAuthority('ADMIN', 'RESOURCE_MANAGER', 'RESOURCE_USER')")
     public ResponseEntity<Map<String, Object>> getAvailableCountByResourceIdAndTimeslot(
             @PathVariable("id") Long resourceId,
-            @RequestParam("timeslot") String timeslot
+            @RequestParam("start") @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime start,
+            @RequestParam("end") @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime end
     ) {
         try {
-            List<ResourceAvailabilityDTO> availabilityList = resourceService.getAvailabilityByResourceIdAndTimeslot(resourceId, timeslot);
+            List<ResourceAvailabilityDTO> availabilityList = resourceService.getAvailabilityByResourceIdAndTimeslot(
+                    resourceId,
+                    start,
+                    end
+            );
             return sendSuccessResponse(availabilityList, HttpStatus.OK);
         } catch (ResourceNotFoundException e) {
             return sendBadRequestResponse(e.getMessage());

--- a/src/main/java/com/csemosip/bookingservice/controller/ResourcesController.java
+++ b/src/main/java/com/csemosip/bookingservice/controller/ResourcesController.java
@@ -49,6 +49,7 @@ public class ResourcesController extends AbstractController {
     }
 
     @GetMapping("/{id}/available")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'RESOURCE_MANAGER', 'RESOURCE_USER')")
     public ResponseEntity<Map<String, Object>> getAvailableCountByResourceIdAndTimeslot(
             @PathVariable("id") Long resourceId,
             @RequestParam("timeslot") String timeslot

--- a/src/main/java/com/csemosip/bookingservice/dto/ResourceAvailabilityDTO.java
+++ b/src/main/java/com/csemosip/bookingservice/dto/ResourceAvailabilityDTO.java
@@ -1,0 +1,20 @@
+package com.csemosip.bookingservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ResourceAvailabilityDTO {
+    @JsonProperty("start")
+    private LocalDateTime startTime;
+    @JsonProperty("end")
+    private LocalDateTime endTime;
+    @JsonProperty("count")
+    private int count;
+}

--- a/src/main/java/com/csemosip/bookingservice/repository/BookingRepository.java
+++ b/src/main/java/com/csemosip/bookingservice/repository/BookingRepository.java
@@ -27,4 +27,15 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
             @Param("resourceId") Long resourceId,
             @Param("startTime") LocalDateTime startTime,
             @Param("endTime") LocalDateTime endTime
-    );}
+    );
+
+    @Query("SELECT b FROM Booking b WHERE " +
+            "b.resource.id = :resourceId AND" +
+            "((b.startTime <= :startTime AND b.endTime >= :endTime) OR " +
+            "((b.startTime >= :startTime AND b.startTime <= :endTime ) OR (b.endTime >= :startTime AND b.endTime <= :endTime)))")
+    List<Booking> getBookingsForResourceInTimeslot(
+            @Param("resourceId") Long resourceId,
+            @Param("startTime") LocalDateTime startTime,
+            @Param("endTime") LocalDateTime endTime
+    );
+}

--- a/src/main/java/com/csemosip/bookingservice/service/Impl/ResourceServiceImpl.java
+++ b/src/main/java/com/csemosip/bookingservice/service/Impl/ResourceServiceImpl.java
@@ -58,21 +58,13 @@ public class ResourceServiceImpl implements ResourceService {
     }
 
     @Override
-    public List<ResourceAvailabilityDTO> getAvailabilityByResourceIdAndTimeslot(Long resourceId, String timeslot) {
+    public List<ResourceAvailabilityDTO> getAvailabilityByResourceIdAndTimeslot(
+            Long resourceId,
+            LocalDateTime startTime,
+            LocalDateTime endTime
+    ) {
         Resource resource = resourceRepository.findById(resourceId)
                 .orElseThrow(() -> new ResourceNotFoundException("Resource not found"));
-
-        // Parse the timeslot string and extract the start and end times
-        LocalDateTime startTime;
-        LocalDateTime endTime;
-        try {
-            String[] times = timeslot.split("-");
-            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm");
-            startTime = LocalDateTime.parse(times[0], dateTimeFormatter);
-            endTime = LocalDateTime.parse(times[1], dateTimeFormatter);
-        } catch (DateTimeParseException | ArrayIndexOutOfBoundsException e) {
-            throw new IllegalArgumentException("Invalid timeslot format");
-        }
 
         // Perform the logic to get the availability count
         List<Booking> overlappingBookings = bookingRepository.getBookingsForResourceInTimeslot(

--- a/src/main/java/com/csemosip/bookingservice/service/ResourceService.java
+++ b/src/main/java/com/csemosip/bookingservice/service/ResourceService.java
@@ -1,10 +1,10 @@
 package com.csemosip.bookingservice.service;
 
+import com.csemosip.bookingservice.dto.ResourceAvailabilityDTO;
 import com.csemosip.bookingservice.dto.ResourceDTO;
 import com.csemosip.bookingservice.model.Resource;
 
 import java.util.List;
-import java.util.Map;
 
 public interface ResourceService {
     List<Resource> findAllResources();
@@ -15,5 +15,5 @@ public interface ResourceService {
 
     Resource updateResource(Long id, ResourceDTO resourceDTO);
 
-    List<Map<String, Object>> getAvailabilityByResourceIdAndTimeslot(Long resourceId, String timeslot);
+    List<ResourceAvailabilityDTO> getAvailabilityByResourceIdAndTimeslot(Long resourceId, String timeslot);
 }

--- a/src/main/java/com/csemosip/bookingservice/service/ResourceService.java
+++ b/src/main/java/com/csemosip/bookingservice/service/ResourceService.java
@@ -4,6 +4,7 @@ import com.csemosip.bookingservice.dto.ResourceAvailabilityDTO;
 import com.csemosip.bookingservice.dto.ResourceDTO;
 import com.csemosip.bookingservice.model.Resource;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ResourceService {
@@ -15,5 +16,9 @@ public interface ResourceService {
 
     Resource updateResource(Long id, ResourceDTO resourceDTO);
 
-    List<ResourceAvailabilityDTO> getAvailabilityByResourceIdAndTimeslot(Long resourceId, String timeslot);
+    List<ResourceAvailabilityDTO> getAvailabilityByResourceIdAndTimeslot(
+            Long resourceId,
+            LocalDateTime start,
+            LocalDateTime end
+    );
 }


### PR DESCRIPTION
There was a previous implementation of ```/resources/{id}/available``` endpoint. But that implementation didn't consider existing overlapping bookings.
The new implementation returns an array with available counts of resource while considering overlapping bookings.